### PR TITLE
use .gitattributes to force unix line endings on .sub files

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.sub text eol=lf


### PR DESCRIPTION
fixes sub files when checking out repo from windows in some configurations